### PR TITLE
Ignore real `master` and current branch in `git cleanup`

### DIFF
--- a/config
+++ b/config
@@ -74,7 +74,7 @@
     find = !sh -c 'git ls-tree -r --name-only HEAD | grep --color $1' - 
 
     #Deletes all branches that were safely merged into the master. All other are skipped (no worries).
-    cleanup = !git branch --merged master | grep -v 'master$' | xargs -r git branch -d  
+    cleanup = !git branch --merged=master | grep -Ev '^\\* | master$' | xargs -r git branch -d
 
     #Deletes orphaned remote branches (.git/refs/remotes/origin), clean up reflog and remove all untracked files
     cleanuplocal = !git remote prune origin && git gc && git clean -df


### PR DESCRIPTION
It might happen that one’s issuing git-cleanup in a freshly-created
branch pointing to master. They probably don’t want to delete it (and
git wouldn’t allow that anyway).

Also, if somebody had a branch named, say, `chessmaster`, it would be
ignored before this PR.