### PR TITLE
Ignore files only locally

### DIFF
--- a/config
+++ b/config
@@ -105,6 +105,9 @@
     # Deletes the remote version of the current branch
     unpublish = "!git push origin :$(git branch-name)"
 
+    # Ignore files only locally
+    hide = update-index --assume-unchanged
+	unhide = update-index --no-assume-unchanged
 [apply]
     whitespace = nowarn
 [core]


### PR DESCRIPTION
Recently I bump into a silly problem that I had to fix by ignoring files locally (only).
It is described by this SO topic: http://stackoverflow.com/questions/1753070/git-ignore-files-only-locally

and since then I have found this two aliases extremely helpful.
```
hide = update-index --assume-unchanged
unhide = update-index --no-assume-unchanged
```

I think it is a good idea to merge those into the main script.
For sure it is also possible to create a "nice" Polish version of the aliases :).
