### PR TITLE
Upper R works only on collors...

### DIFF
--- a/config
+++ b/config
@@ -124,7 +124,7 @@
 [apply]
     whitespace = nowarn
 [core]
-    pager = less -r
+    pager = less -R
 [help]
     autocorrect = 1 #fucking magic!
 


### PR DESCRIPTION
Lets change less option to -R, it's almost the same like r, but works only for color.
Why?
In my Centos first one or two lines of history (git llog) are not visible when paging is involved.
With -R it works as expected.
