### PR TITLE
Set 'push.default' to 'upstream'

### DIFF
--- a/config
+++ b/config
@@ -2,7 +2,7 @@
     autosetupmerge = true
 
 [push]
-    default = tracking
+    default = upstream
 [rerere]
     enabled = true
 [rebase]


### PR DESCRIPTION
`tracking` value is deprecated and even **not** mentioned on official [git-config page](https://git-scm.com/docs/git-config).