### PR TITLE
Provide aliases to delete git tags (PL)

### DIFF
--- a/configNSFW_PL
+++ b/configNSFW_PL
@@ -30,6 +30,8 @@
     tagikurwa = show-ref --tags
     pchajtagikurwa = push --tags
     tagujzdatakurwa = !sh -c 'git tag "$0"_$(date "+%y-%m-%d_%H-%M-%S")'
+	wyjebtag = !sh -c 'git tag -d "$0"'
+	wyjebtagwchuj = !sh -c 'git tag -d "$0" && git push --delete origin tag "$0"'
 
     pojebalosiekurwa = reset --hard
 

--- a/configNSFW_PL
+++ b/configNSFW_PL
@@ -30,8 +30,8 @@
     tagikurwa = show-ref --tags
     pchajtagikurwa = push --tags
     tagujzdatakurwa = !sh -c 'git tag "$0"_$(date "+%y-%m-%d_%H-%M-%S")'
-	wyjebtag = !sh -c 'git tag -d "$0"'
-	wyjebtagwchuj = !sh -c 'git tag -d "$0" && git push --delete origin tag "$0"'
+    wyjebtag = !sh -c 'git tag -d "$0"'
+    wyjebtagwchuj = !sh -c 'git tag -d "$0" && git push --delete origin tag "$0"'
 
     pojebalosiekurwa = reset --hard
 


### PR DESCRIPTION
## wyjebtag
```console
git wyjebtag <tag>
```
Removes local git tag.
## wyjebtagwchuj
```console
git wyjebtagwchuj <tag>
```
Removes both local and remote tag.