### PR TITLE
More readable colors in 'git hist'

### DIFF
--- a/config
+++ b/config
@@ -14,6 +14,8 @@
     current = yellow reverse
     local = yellow
     remote = green
+[color "decorate"]
+    remoteBranch = blue
 [color "diff"]
     meta = yellow bold
     frag = magenta bold
@@ -46,8 +48,10 @@
 
     #BASIC HISTORY VIEWING
 
-    hist = log --pretty=format:'%Cred%h%Creset %C(bold blue)<%an>%Creset%C(yellow)%d%Creset %Cgreen(%cr)%Creset%n%w(80,8,8)%s' --graph
-    histfull = log --pretty=format:'%Cred%h%Creset %C(bold blue)<%an>%Creset%C(yellow)%d%Creset %Cgreen(%cr)%Creset%n%w(80,8,8)%s%n' --graph --name-status
+    hist = log --graph --date=relative \
+        --format=format:'%C(auto)%h%d%C(reset) %C(white dim)%an, %ad%C(reset)%n%w(80,8,8)%s'
+    histfull = log --graph --date=relative --name-status \
+        --format=format:'%C(auto)%h%d%C(reset) %C(white dim)%an, %ad%C(reset)%n%w(80,8,8)%s%n'
     llog = log --pretty=format:'%C(yellow)%h %Cred%ad %Cblue%an%Cgreen%d %Creset%s' --date=iso
     changelog = log --pretty=format:'%Cgreen%d %Creset%s' --date=iso
     ls = log --pretty=format:'%C(yellow)%p..%h %C(white dim)%cd %<|(49,trunc)%an %C(reset)%s' --date=short --abbrev=8 --no-merges


### PR DESCRIPTION
before and after image:
![git-hist-before-and-after](https://user-images.githubusercontent.com/1368508/48184221-a242f580-e331-11e8-82d3-1d18500162eb.png)

* use "auto" (yellow) instead of red for commit hashes
  Having so much red in the output sends an alarming message to the
  viewer, as red is associated with errors.

* use "auto" instead of yellow for ref names
  This makes git color refs according to their type: tags yellow, HEAD
  cyan, local branches green and remote branches red. Different colors
  make navigating through the log and finding desired branch/tag easier.
  Also, use blue (instead of default red) for remote branches.

* put ref names at the beginning of line
  Sometimes there are multiple branches and/or tags pointing to a ref,
  and the list may be so long that the first line won't fit on the
  screen. Since branch information is more important than authorship,
  put it first so that more of it is visible in such cases

* use "white dim" (grey) for author and date
  This is secondary content, and it repeats a lot across commits, so it
  shouldn't be highlighted in bold and intense colors. Rather, it should
  be dimmer than commit message, to make searching for a particular
  commit (by its message) or branch (by its name) easier.