### PR TITLE
More readable colors in 'git hist'

### DIFF
--- a/config
+++ b/config
@@ -14,6 +14,8 @@
     current = yellow reverse
     local = yellow
     remote = green
+[color "decorate"]
+    remoteBranch = blue bold
 [color "diff"]
     meta = yellow bold
     frag = magenta bold
@@ -47,8 +49,10 @@
 
     #BASIC HISTORY VIEWING
 
-    hist = log --pretty=format:'%Cred%h%Creset %C(bold blue)<%an>%Creset%C(yellow)%d%Creset %Cgreen(%cr)%Creset%n%w(80,8,8)%s' --graph
-    histfull = log --pretty=format:'%Cred%h%Creset %C(bold blue)<%an>%Creset%C(yellow)%d%Creset %Cgreen(%cr)%Creset%n%w(80,8,8)%s%n' --graph --name-status
+    hist = log --graph --date=relative \
+        --format=format:'%C(auto)%h %C(bold blue)%an%C(auto)%d %C(green)%ad%C(reset)%n%w(80,8,8)%s'
+    histfull = log --graph --date=relative --name-status \
+        --format=format:'%C(auto)%h %C(bold blue)%an%C(auto)%d %C(green)%ad%C(reset)%n%w(80,8,8)%s%n'
     llog = log --pretty=format:'%C(yellow)%h %Cred%ad %Cblue%an%Cgreen%d %Creset%s' --date=iso
     changelog = log --pretty=format:'%Cgreen%d %Creset%s' --date=iso
     ls = log --pretty=format:'%C(yellow)%p..%h %C(white dim)%cd %<|(49,trunc)%an %C(reset)%s' --date=short --abbrev=8 --no-merges

--- a/configNSFW_HU
+++ b/configNSFW_HU
@@ -4,6 +4,8 @@
     current = yellow reverse
     local = yellow
     remote = green
+[color "decorate"]
+    remoteBranch = blue bold
 [color "diff"]
     meta = yellow bold
     frag = magenta bold
@@ -15,8 +17,10 @@
     untracked = cyan
 
 [alias]
-    kibaszottfa = log --pretty=format:'%Cred%h%Creset %C(bold blue)<%an>%Creset%C(yellow)%d%Creset %Cgreen(%cr)%Creset%n%w(80,8,8)%s' --graph
-    kibaszottnagyfa = log --pretty=format:'%Cred%h%Creset %C(bold blue)<%an>%Creset%C(yellow)%d%Creset %Cgreen(%cr)%Creset%n%w(80,8,8)%s%n' --graph --name-status
+    kibaszottfa = log --graph --date=relative \
+        --format=format:'%C(auto)%h %C(bold blue)%an%C(auto)%d %C(green)%ad%C(reset)%n%w(80,8,8)%s'
+    kibaszottnagyfa = log --graph --date=relative --name-status \
+        --format=format:'%C(auto)%h %C(bold blue)%an%C(auto)%d %C(green)%ad%C(reset)%n%w(80,8,8)%s%n'
     kurvakommitok = log --pretty=format:'%C(yellow)%h %Cred%ad %Cblue%an%Cgreen%d %Creset%s' --date=iso
 
     kiakurvaanyja = "!sh -c 'git log -i -1 --pretty=\"format::%an <%ae>\n\" --author=\"$1\"' -"

--- a/configNSFW_LT
+++ b/configNSFW_LT
@@ -4,6 +4,8 @@
     current = yellow reverse
     local = yellow
     remote = green
+[color "decorate"]
+    remoteBranch = blue bold
 [color "diff"]
     meta = yellow bold
     frag = magenta bold
@@ -15,8 +17,10 @@
     untracked = cyan
 
 [alias]
-    mediskurva = log --pretty=format:'%Cred%h%Creset %C(bold blue)<%an>%Creset%C(yellow)%d%Creset %Cgreen(%cr)%Creset%n%w(80,8,8)%s' --graph
-    medisnxkurva = log --pretty=format:'%Cred%h%Creset %C(bold blue)<%an>%Creset%C(yellow)%d%Creset %Cgreen(%cr)%Creset%n%w(80,8,8)%s%n' --graph --name-status
+    mediskurva = log --graph --date=relative \
+        --format=format:'%C(auto)%h %C(bold blue)%an%C(auto)%d %C(green)%ad%C(reset)%n%w(80,8,8)%s'
+    medisnxkurva = log --graph --date=relative --name-status \
+        --format=format:'%C(auto)%h %C(bold blue)%an%C(auto)%d %C(green)%ad%C(reset)%n%w(80,8,8)%s%n'
     komitaikurva = log --pretty=format:'%C(yellow)%h %Cred%ad %Cblue%an%Cgreen%d %Creset%s' --date=iso
 
     kastaskurva = "!sh -c 'git log -i -1 --pretty=\"format::%an <%ae>\n\" --author=\"$1\"' -"

--- a/configNSFW_PL
+++ b/configNSFW_PL
@@ -4,6 +4,8 @@
     current = yellow reverse
     local = yellow
     remote = green
+[color "decorate"]
+    remoteBranch = blue bold
 [color "diff"]
     meta = yellow bold
     frag = magenta bold
@@ -15,8 +17,10 @@
     untracked = cyan
 
 [alias]
-    drzewokurwa = log --pretty=format:'%Cred%h%Creset %C(bold blue)<%an>%Creset%C(yellow)%d%Creset %Cgreen(%cr)%Creset%n%w(80,8,8)%s' --graph
-    duzedrzewokurwa = log --pretty=format:'%Cred%h%Creset %C(bold blue)<%an>%Creset%C(yellow)%d%Creset %Cgreen(%cr)%Creset%n%w(80,8,8)%s%n' --graph --name-status
+    drzewokurwa = log --graph --date=relative \
+        --format=format:'%C(auto)%h %C(bold blue)%an%C(auto)%d %C(green)%ad%C(reset)%n%w(80,8,8)%s'
+    duzedrzewokurwa= log --graph --date=relative --name-status \
+        --format=format:'%C(auto)%h %C(bold blue)%an%C(auto)%d %C(green)%ad%C(reset)%n%w(80,8,8)%s%n'
     komitykurwa = log --pretty=format:'%C(yellow)%h %Cred%ad %Cblue%an%Cgreen%d %Creset%s' --date=iso
 
     ktotokurwa = "!sh -c 'git log -i -1 --pretty=\"format::%an <%ae>\n\" --author=\"$1\"' -"

--- a/configNSFW_PT-BR
+++ b/configNSFW_PT-BR
@@ -4,6 +4,8 @@
     current = yellow reverse
     local = yellow
     remote = green
+[color "decorate"]
+    remoteBranch = blue bold
 [color "diff"]
     meta = yellow bold
     frag = magenta bold
@@ -15,8 +17,10 @@
     untracked = cyan
 
 [alias]
-    passadoporra = log --pretty=format:'%Cred%h%Creset %C(bold blue)<%an>%Creset%C(yellow)%d%Creset %Cgreen(%cr)%Creset%n%w(80,8,8)%s' --graph
-    mostratudoporra = log --pretty=format:'%Cred%h%Creset %C(bold blue)<%an>%Creset%C(yellow)%d%Creset %Cgreen(%cr)%Creset%n%w(80,8,8)%s%n' --graph --name-status
+    passadoporra = log --graph --date=relative \
+        --format=format:'%C(auto)%h %C(bold blue)%an%C(auto)%d %C(green)%ad%C(reset)%n%w(80,8,8)%s'
+    mostratudoporra = log --graph --date=relative --name-status \
+        --format=format:'%C(auto)%h %C(bold blue)%an%C(auto)%d %C(green)%ad%C(reset)%n%w(80,8,8)%s%n'
     datanessaporra = log --pretty=format:'%C(yellow)%h %Cred%ad %Cblue%an%Cgreen%d %Creset%s' --date=iso
 
     quemporra = "!sh -c 'git log -i -1 --pretty=\"format::%an <%ae>\n\" --author=\"$1\"' -"


### PR DESCRIPTION
Replaces #60 (I cannot edit that one because I've deleted my fork in the meantime).

* use "auto" (yellow) instead of red for commit hashes
  Having so much red in the output sends an alarming message to the
  viewer, as red is associated with errors.

* use "auto" instead of yellow for ref names
  This makes git color refs according to their type: tags yellow, HEAD
  cyan, local branches green and remote branches red. Different colors
  make navigating through the log and finding desired branch/tag easier.
  Also, use blue (instead of default red) for remote branches.