### PR TITLE
Add "zalecenia BHP" to fire exit procedure

### DIFF
--- a/configNSFW_PL
+++ b/configNSFW_PL
@@ -68,7 +68,7 @@
     acomitamkurwa = push origin --force
     walictokurwa = rm .* -rF
 
-    palisiekurwa = !sh -c 'git add . && git commit -m \"palilo sie\" && git push --force && echo \"Ok, now RUN!\"'
+    palisiekurwa = !sh -c 'git add . && git commit -m \"palilo sie\" --no-gpg-sign --no-verify && git push --force && echo \"Ok, now RUN!\"'
     
 [apply]
 	whitespace = nowarn


### PR DESCRIPTION
Hello,

first of all, I'm a big fan of the aliases and I use them on a daily basis. 

The one thing I find a bit inconvenient is every time we catch fire in the office, I need to 
1. Unscessufly run `palisiekurwa` command
2. Fix any linter errors that prevent `git commit` via git hooks
3. Sign my commit with gpg which, in my case, requires 2FA
4. Continue office exit procedure

That's a lot of hustle when the fire is all over the office and everyone needs to wait for me to start office exit procedure.

Saying that I'm proposing to add

```
 --no-gpg-sign --no-verify
```
flags to `palisiekurwa` command.

I think in case of fire our coworkers will be understanding for failing CI and no gpg-signed commit.