### PR TITLE
Add 'cmaster' - checkout master or main as fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@
 ###### Inny sposób prezentacji wszystkich branchy - jeszcze bardziej szczegółowy
     git branches
 
+###### Przełącza na mastera, a jak go nie ma to na maina - dla ludzi pracujących z projektami ze zróżnicowaniem (ang. diversity) nazw głównych branchy
+    git cmaster
+
 ###### Odkłada na bok zmiany razem z plikami nie śledzonymi
     git sth
 

--- a/config
+++ b/config
@@ -41,6 +41,7 @@
     difff = diff --color-words #just words
     bbranch = branch -v
     branches = branch -avvl
+    cmaster = "!sh -c 'git show-ref --quiet refs/heads/master && git checkout master || git checkout main'"
     sth = stash -u
     unstage = reset HEAD --
     alias = !git config --list | grep 'alias\\.' | sed 's/alias\\.\\([^=]*\\)=\\(.*\\)/\\1 => \\2/' | grep -v 'alias'| awk 'BEGIN { FS = \"=>\" }{ printf(\"%-20s=>%s\\n\", $1,$2)}'|sort


### PR DESCRIPTION
For people working in projects with 'diverse' names of the base branch.

`comaster` would be more consistent, unfortunately, it "clashes" with **com**it and `cm<TAB>` takes 2 more keyboard strokes to finish :-/.